### PR TITLE
Remove credentials plugin to avoid dependency confilct

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -1,4 +1,3 @@
-credentials:2.1.18
 credentials-binding:1.18
 git:3.9.1
 kubernetes:1.14.9


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/19322

Problem:
credentials-binding has dependency of "SSH Credentials" plugin. On installation it implicitly installs the latest "SSH Credentials" plugin as the dependency, which requires a newer v2.2.0 credentials plugin, so the claimed plugin version is not satisfied.

Solution:
Remove credentials plugin from the list, a proper version of it will be installed by dependencies.

Reference:
See plugin dependencies
https://plugins.jenkins.io/credentials-binding
https://plugins.jenkins.io/ssh-credentials